### PR TITLE
feat: Detect cursor position in array to sort it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "sort-json-array",
-    "version": "0.0.2",
+    "version": "1.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -96,6 +96,16 @@
             "integrity": "sha512-uUpjvtrQ14ZEqqRE/EGuBvGbm9GuxDp76mtsnw3goMogsWmEEYS/y4eL2Zwf0rbFMh/hg3hEs+E3CvuuNEs+GA==",
             "dev": true
         },
+        "acorn": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+            "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+        },
+        "acorn-walk": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
+            "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg=="
+        },
         "agent-base": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -144,14 +154,12 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -280,8 +288,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "debug": {
             "version": "3.2.6",
@@ -411,8 +418,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "function-bind": {
             "version": "1.1.1",
@@ -436,7 +442,6 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
             "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -520,7 +525,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -529,8 +533,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "is-buffer": {
             "version": "2.0.4",
@@ -625,7 +628,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -633,14 +635,12 @@
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -702,7 +702,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
             "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-            "dev": true,
             "requires": {
                 "mkdirp": "~0.5.1",
                 "ncp": "~2.0.0",
@@ -713,7 +712,6 @@
                     "version": "6.0.4",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-                    "dev": true,
                     "requires": {
                         "inflight": "^1.0.4",
                         "inherits": "2",
@@ -726,7 +724,6 @@
                     "version": "2.4.5",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                     "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-                    "dev": true,
                     "requires": {
                         "glob": "^6.0.1"
                     }
@@ -736,8 +733,7 @@
         "ncp": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-            "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-            "dev": true
+            "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
         },
         "node-environment-flags": {
             "version": "1.0.5",
@@ -787,7 +783,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -825,8 +820,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-parse": {
             "version": "1.0.6",
@@ -946,7 +940,6 @@
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
             "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
-            "dev": true,
             "requires": {
                 "rimraf": "~2.6.2"
             },
@@ -955,7 +948,6 @@
                     "version": "2.6.3",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -1015,8 +1007,7 @@
         "typescript": {
             "version": "3.6.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-            "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
-            "dev": true
+            "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
         },
         "vscode-test": {
             "version": "1.2.0",
@@ -1106,8 +1097,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "y18n": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,10 +60,12 @@
         "test": "npm run compile && node ./out/test/runTest.js"
     },
     "dependencies": {
-        "typescript": "^3.6.1",
+        "acorn": "^7.1.0",
+        "acorn-walk": "^7.0.0",
         "glob": "^7.1.4",
         "mv": "^2.1.1",
-        "temp": "^0.9.0"
+        "temp": "^0.9.0",
+        "typescript": "^3.6.1"
     },
     "devDependencies": {
         "@types/chai": "^4.2.3",

--- a/src/findArrayInText.ts
+++ b/src/findArrayInText.ts
@@ -1,0 +1,29 @@
+const { parse } = require('acorn');
+const { findNodeAround, findNodeAfter } = require('acorn-walk');
+
+const BRACKETS_REGEX = /[[\]]/g;
+
+export type FoundArray = {
+  text: string,
+  start: number,
+  end: number 
+};
+
+/**
+ * Will find a enclosing pair of [] around the given `offset` in `text`.
+ * 
+ * @param text to parse
+ * @param offset to parse around.
+ * @returns FoundArray or undefined if nothing was found
+ */
+export function findArrayInText(text: string, offset: number) : FoundArray|undefined {
+  const root = parse(text);
+  let array = findNodeAround(root, offset, 'ArrayExpression');
+  if (array) {
+    const { start, end } = array.node;
+    text = text.substring(start, end);
+    return {
+      text, start, end
+    };
+  }
+}

--- a/src/test/suite/findArrayInText.test.ts
+++ b/src/test/suite/findArrayInText.test.ts
@@ -1,0 +1,26 @@
+import chai = require('chai');
+const expect = chai.expect;
+
+import { findArrayInText } from '../../findArrayInText';
+
+suite('Find array in text', () => {
+  test('Find simple match', () => {
+    expect(
+      findArrayInText('[ 1, 2, 3 ]', 3)
+    ).to.deep.equal(
+      { start: 0, end: 11, text: '[ 1, 2, 3 ]' }
+    );
+  });
+  test('Find across sub array items', () => {
+    expect(
+      findArrayInText('[ [1], [2], [3] ]', 11)
+    ).to.deep.equal({ start: 0, end: 17, text: '[ [1], [2], [3] ]' });
+  });
+  test('Find with object items', () => {
+    expect(
+      findArrayInText('[ { "key": 1 }, { "key": 2 }, { "key": 3 } ]', 10)
+    ).to.deep.equal(
+      { start: 0, end: 44, text: '[ { "key": 1 }, { "key": 2 }, { "key": 3 } ]' }
+    );
+  });
+});


### PR DESCRIPTION
With this there is no need to select the array before sorting it.
Just place the cursor anywhere in the array and sort it.
![IpvcsBDKOM](https://user-images.githubusercontent.com/164625/67152706-c5657b80-f2dc-11e9-94b8-746f1634ec3a.gif)



If this works good enough we might add AST parsing for the selection the
same way. That would ensure that even partially selected arrays get properly
detected.
Or we can ditch the selection based detection all together.

Then, since we have a proper AST of the array now, we could (instead of
parsing it using JSON.parse) sort the AST elements and maybe then
transform the  AST back to source code to not change the code
formatting like it is happening now.